### PR TITLE
Include CAPROVER_GIT_COMMIT_SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ jobs:
                   echo "IMAGE_NAME_WITH_REGISTRY=$DOCKER_REGISTRY/$IMAGE_NAME" >> $GITHUB_ENV
                   export IMAGE_NAME_WITH_REGISTRY=$DOCKER_REGISTRY/$IMAGE_NAME
                   echo "FULL_IMAGE_NAME=$IMAGE_NAME_WITH_REGISTRY:$GITHUB_SHA-gitsha" >> $GITHUB_ENV
+                  echo "CAPROVER_GIT_COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
             - name: Log in to the Container registry
               uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
               with:


### PR DESCRIPTION
The "deploy using image" steps result in the CAPROVER_GIT_COMMIT_SHA build arg not being included. This updates the example in the README so that the CAPROVER_GIT_COMMIT_SHA does ends up as a build arg.