### PR TITLE
Pin CapRover CLI to 2.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine
 LABEL org.opencontainers.image.source = "https://github.com/caprover/deploy-from-github"
 
 RUN apk add --no-cache git \
- && npm i -g caprover \
+ && npm i -g caprover@2.4.3 \
  && npm cache clean --force
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary

Pin the CapRover CLI installed by the action to version 2.4.3.

## Root cause

The action previously installed the unbounded latest CLI release. It therefore picked up CLI 2.4.2 automatically.

CLI 2.4.2 upgraded to Commander 12 but still treated Commander's trailing command object as a positional parameter, causing valid deployments to fail with:

```text
Positional parameter not supported: [object Object]
```

CLI 2.4.3 fixes the callback handling. Pinning the version also makes future CLI upgrades deliberate and testable.

## Validation

- Reproduced the reported failure with `caprover@2.4.2`
- Confirmed the same deploy invocation reaches the deployment flow with `caprover@2.4.3`
- Confirmed `caprover@2.4.3` is published on npm
- Ran `git diff --check`

Closes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the CapRover command-line tool to version 2.4.3 for more consistent application deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->